### PR TITLE
replace AbstractStandardShape{T} by AbstractShape

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package provides the following shapes: `StandardPoint`, `StandardLine`, `St
 ### StandardPoint
 
 ```
-struct StandardPoint{T} <: AbstractStandardShape end
+struct StandardPoint{T} <: AbstractShape end
 ```
 
 `StandardPoint` is a point placed at the origin. It doesn't require any fields.
@@ -47,7 +47,7 @@ struct StandardPoint{T} <: AbstractStandardShape end
 ### StandardLine
 
 ```
-struct StandardLine{T} <: AbstractStandardShape
+struct StandardLine{T} <: AbstractShape
     half_length::T
 end
 ```
@@ -59,7 +59,7 @@ end
 ### StandardCircle
 
 ```
-struct StandardCircle{T} <: AbstractStandardShape
+struct StandardCircle{T} <: AbstractShape
     radius::T
 end
 ```
@@ -71,7 +71,7 @@ end
 ### StandardRect
 
 ```
-struct StandardRect{T} <: AbstractStandardShape
+struct StandardRect{T} <: AbstractShape
     half_width::T
     half_height::T
 end

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package provides the following shapes: `StandardPoint`, `StandardLine`, `St
 ### StandardPoint
 
 ```
-struct StandardPoint{T} <: AbstractStandardShape{T} end
+struct StandardPoint{T} <: AbstractStandardShape end
 ```
 
 `StandardPoint` is a point placed at the origin. It doesn't require any fields.
@@ -47,7 +47,7 @@ struct StandardPoint{T} <: AbstractStandardShape{T} end
 ### StandardLine
 
 ```
-struct StandardLine{T} <: AbstractStandardShape{T}
+struct StandardLine{T} <: AbstractStandardShape
     half_length::T
 end
 ```
@@ -59,7 +59,7 @@ end
 ### StandardCircle
 
 ```
-struct StandardCircle{T} <: AbstractStandardShape{T}
+struct StandardCircle{T} <: AbstractStandardShape
     radius::T
 end
 ```
@@ -71,7 +71,7 @@ end
 ### StandardRect
 
 ```
-struct StandardRect{T} <: AbstractStandardShape{T}
+struct StandardRect{T} <: AbstractStandardShape
     half_width::T
     half_height::T
 end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,16 +1,16 @@
-abstract type AbstractStandardShape end
+abstract type AbstractShape end
 
 #####
 # StandardPoint
 #####
 
-struct StandardPoint{T} <: AbstractStandardShape end
+struct StandardPoint{T} <: AbstractShape end
 
 #####
 # StandardLine
 #####
 
-struct StandardLine{T} <: AbstractStandardShape
+struct StandardLine{T} <: AbstractShape
     half_length::T
 end
 
@@ -35,7 +35,7 @@ get_vertices(line::StandardLine{T}, pos::Vector2D{T}, dir::Vector2D{T}) where {T
 # StandardCircle
 #####
 
-struct StandardCircle{T} <: AbstractStandardShape
+struct StandardCircle{T} <: AbstractShape
     radius::T
 end
 
@@ -50,7 +50,7 @@ end
 # StandardRect
 #####
 
-struct StandardRect{T} <: AbstractStandardShape
+struct StandardRect{T} <: AbstractShape
     half_width::T
     half_height::T
 end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,16 +1,16 @@
-abstract type AbstractStandardShape{T} end
+abstract type AbstractStandardShape end
 
 #####
 # StandardPoint
 #####
 
-struct StandardPoint{T} <: AbstractStandardShape{T} end
+struct StandardPoint{T} <: AbstractStandardShape end
 
 #####
 # StandardLine
 #####
 
-struct StandardLine{T} <: AbstractStandardShape{T}
+struct StandardLine{T} <: AbstractStandardShape
     half_length::T
 end
 
@@ -35,7 +35,7 @@ get_vertices(line::StandardLine{T}, pos::Vector2D{T}, dir::Vector2D{T}) where {T
 # StandardCircle
 #####
 
-struct StandardCircle{T} <: AbstractStandardShape{T}
+struct StandardCircle{T} <: AbstractStandardShape
     radius::T
 end
 
@@ -50,7 +50,7 @@ end
 # StandardRect
 #####
 
-struct StandardRect{T} <: AbstractStandardShape{T}
+struct StandardRect{T} <: AbstractStandardShape
     half_width::T
     half_height::T
 end


### PR DESCRIPTION
1. Remove type parameter `T` from `AbstractStandardShape{T}`.
2. Rename `AbstractStandardShape` to `AbstractShape`.